### PR TITLE
ART-12521: go mod vendor fix

### DIFF
--- a/vendor/github.com/spf13/cobra/command.go
+++ b/vendor/github.com/spf13/cobra/command.go
@@ -1098,12 +1098,6 @@ func (c *Command) ExecuteC() (cmd *Command, err error) {
 
 	// initialize help at the last point to allow for user overriding
 	c.InitDefaultHelpCmd()
-	// initialize completion at the last point to allow for user overriding
-	c.InitDefaultCompletionCmd()
-
-	// Now that all commands have been created, let's make sure all groups
-	// are properly created also
-	c.checkCommandGroups()
 
 	args := c.args
 


### PR DESCRIPTION
Image build was failing on Konflux due to outdated go mod dependencies.

```
2025-04-18 17:50:45,909 ERROR vendor directory changed after vendoring:
M	vendor/github.com/spf13/cobra/command.go
2025-04-18 17:50:47,117 ERROR PackageRejected: The content of the vendor directory is not consistent with go.mod. Please check the logs for more details.
```

Konflux ignores .gitignore files since its a possible security gap. 