### PR TITLE
CNF-21001: Remove iptables compatibility commits

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -17,7 +17,4 @@ LABEL io.k8s.display-name="Multus NetworkPolicy" \
       io.openshift.tags="openshift" \
       maintainer="Doug Smith <dosmith@redhat.com>"
 
-# TODO: compatibility layer with the original multus-networkpolicy-iptables image. Remove this once the ClsuterNetworkOperator is updated to use the nftables implementation. 
-RUN ln -s /usr/bin/multi-networkpolicy-nftables /usr/bin/multi-networkpolicy-iptables
-
 ENTRYPOINT ["multi-networkpolicy-nftables"]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -64,10 +64,6 @@ func run() error {
 	flag.StringVar(&customIPv6IngressRuleFile, "custom-v6-ingress-rule-file", "", "custom rule file for IPv6 ingress")
 	flag.StringVar(&customIPv6EgressRuleFile, "custom-v6-egress-rule-file", "", "custom rule file for IPv6 egress")
 
-	// TODO: compatibility layer with the multus-networkpolicy-iptables image. Remove this once the ClsuterNetworkOperator is updated to use the nftables implementation.
-	var podIptables string
-	flag.StringVar(&podIptables, "pod-iptables", "", "compatibility layer")
-
 	opts := zap.Options{
 		Development: true,
 	}
@@ -105,9 +101,6 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("unable to get custom nftables rules: %w", err)
 	}
-
-	// TODO: compatibility layer with the multus-networkpolicy-iptables image. Remove this once the ClsuterNetworkOperator is updated to use the nftables implementation.
-	commonRules = &nftables.CommonRules{}
 
 	// Set ICMP acceptance rules
 	commonRules.AcceptICMP = acceptICMP

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -113,20 +113,6 @@ func run() error {
 	commonRules.AcceptICMP = acceptICMP
 	commonRules.AcceptICMPv6 = acceptICMPv6
 
-	// TODO: put this in ClusterNetworkOperator
-	commonRules.CustomIPv6EgressRules = []string{
-		"icmpv6 type nd-neighbor-solicit accept",
-		"icmpv6 type nd-neighbor-advert accept",
-		"icmpv6 type nd-router-advert accept",
-		"icmpv6 type nd-router-solicit accept",
-	}
-	commonRules.CustomIPv6IngressRules = []string{
-		"icmpv6 type nd-neighbor-solicit accept",
-		"icmpv6 type nd-neighbor-advert accept",
-		"icmpv6 type nd-router-advert accept",
-		"icmpv6 type nd-router-solicit accept",
-	}
-
 	setupLog.Info("Common rules applied to all pods affected by MultiNetworkPolicies", "rules", commonRules)
 
 	ctx := ctrl.SetupSignalHandler()


### PR DESCRIPTION
Since 
- https://github.com/openshift/cluster-network-operator/pull/2883

has been merged, we can remove the compatibility with the old iptables implementation