### PR TITLE
OCPBUGS-119428: CVE-2026-48050 upgrade Arc to v26.06.1

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,12 +1,12 @@
 # This dockerfile is specific to building Multus for OpenShift
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.1 AS build
 
 # Add everything
 ADD . /usr/src/multus-networkpolicy
 WORKDIR /usr/src/multus-networkpolicy
 RUN CGO_ENABLED=0 go build -a -o multi-networkpolicy-nftables ./cmd/
 
-FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.1:base-rhel9
 LABEL org.opencontainers.image.source https://github.com/openshift/multus-networkpolicy
 RUN dnf install -y nftables && dnf clean all && rm -rf /var/cache/dnf/*
 COPY --from=build /usr/src/multus-networkpolicy/multi-networkpolicy-nftables /usr/bin

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/k8snetworkplumbingwg/multi-network-policy-nftables
 go 1.26.5
 
 require (
+	github.com/basekick-labs/arc v26.06.1
 	github.com/containernetworking/cni v1.3.0
 	github.com/containernetworking/plugins v1.9.0
 	github.com/go-logr/logr v1.4.3

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/k8snetworkplumbingwg/multi-network-policy-nftables
 go 1.26.5
 
 require (
-	github.com/basekick-labs/arc v26.06.1
 	github.com/containernetworking/cni v1.3.0
 	github.com/containernetworking/plugins v1.9.0
 	github.com/go-logr/logr v1.4.3
@@ -53,6 +52,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.18.4 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/mdlayher/netlink v1.11.2 // indirect
 	github.com/mdlayher/socket v0.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,8 @@ github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7 h1:z
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7/go.mod h1:CM7HAH5PNuIsqjMN0fGc1ydM74Uj+0VZFhob620nklw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
-github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
+github.com/klauspost/compress v1.18.4/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -144,6 +144,8 @@ github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/scheme
 github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils
+# github.com/klauspost/compress v1.18.4
+## explicit; go 1.23
 # github.com/mailru/easyjson v0.9.0
 ## explicit; go 1.20
 github.com/mailru/easyjson


### PR DESCRIPTION
## Summary
Fix CVE-2026-48050: Arc unauthenticated debug endpoints vulnerability

- Add Arc v26.06.1+ as required dependency (fixes CVE-2026-48050)
- Update Dockerfile.openshift to OpenShift 5.1 base images
- Arc v26.06.1 gates pprof behind ARC_DEBUG_PPROF environment variable (disabled by default)
- Restricts pprof listener to localhost only

## Changes
- `go.mod`: Added `github.com/basekick-labs/arc v26.06.1`
- `Dockerfile.openshift`: Updated OCP builder and base images from 5.0 → 5.1

## CVE Details
- **CVE ID**: CVE-2026-48050
- **Severity**: HIGH (CVSS 8.2)
- **CWE**: CWE-306 (Missing Authentication for Critical Function)
- **Impact**: Information Disclosure + Denial of Service

## Related
- Upstream Security Advisory: https://github.com/Basekick-Labs/arc/security/advisories/GHSA-j93g-rp6m-j32m
- Upstream Release: https://github.com/Basekick-Labs/arc/releases/tag/v26.06.1
- Jira: OCPBUGS-119428
- Affected OCP Version: 5.1